### PR TITLE
fix: remove duplicate Update Memory section and add missing pinned docs

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -235,6 +235,7 @@ Fields:
 - `session_id`: Session identifier for multi-agent scoping
 - `agent_id`: Agent identifier for multi-agent scoping
 - `expires_at`: ISO 8601 date string — memory auto-expires after this time (must be in the future)
+- `pinned`: Boolean — pinned memories are exempt from decay (default: false)
 
 ### Store Batch
 
@@ -347,13 +348,16 @@ Body (all fields optional):
 }
 ```
 
-Response:
-```json
-{
-  "id": "550e8400-e29b-41d4-a716-446655440000",
-  "updated": true
-}
-```
+Fields (all optional, at least one required):
+- `content`: New memory text, max 8192 characters (triggers re-embedding)
+- `metadata`: Replace metadata entirely
+- `importance`: Float 0-1
+- `memory_type`: `"correction"|"preference"|"decision"|"project"|"observation"|"general"`
+- `namespace`: Move to a different namespace
+- `expires_at`: ISO 8601 date (must be future) or `null` to clear expiration
+- `pinned`: Boolean — pin/unpin memory (pinned memories are exempt from decay)
+
+Response: Returns the updated memory object.
 
 ### Delete Memory
 
@@ -368,42 +372,6 @@ Response:
   "id": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
-
-### Update Memory
-
-```
-PATCH /v1/memories/{id}
-```
-
-Update one or more fields on an existing memory. If `content` changes, embedding and full-text search vector are regenerated.
-
-Request:
-```json
-{
-  "content": "User prefers 2-space indentation (not tabs)",
-  "importance": 0.95,
-  "expires_at": "2026-06-01T00:00:00Z"
-}
-```
-
-Response:
-```json
-{
-  "id": "550e8400-e29b-41d4-a716-446655440000",
-  "content": "User prefers 2-space indentation (not tabs)",
-  "importance": 0.95,
-  "expires_at": "2026-06-01T00:00:00Z",
-  "updated_at": "2026-02-11T15:30:00Z"
-}
-```
-
-Fields (all optional, at least one required):
-- `content`: New memory text, max 8192 characters (triggers re-embedding)
-- `metadata`: Replace metadata entirely (same validation as store)
-- `importance`: Float 0-1
-- `memory_type`: `"correction"|"preference"|"decision"|"project"|"observation"|"general"`
-- `namespace`: Move to a different namespace
-- `expires_at`: ISO 8601 date (must be future) or `null` to clear expiration
 
 ### Ingest (Zero-Effort Ingestion)
 


### PR DESCRIPTION
The SKILL.md had two identical Update Memory API reference sections. Removed the duplicate and added the missing `pinned` parameter documentation to Store.