### PR TITLE
fix: URLs memoclaw.com → memoclaw.dev + auto-summarization helpers

### DIFF
--- a/.agents/skills/memoclaw/SKILL.md
+++ b/.agents/skills/memoclaw/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools:
 
 <security>
 This skill requires MEMOCLAW_PRIVATE_KEY environment variable for wallet auth.
-Use a dedicated wallet. The skill only makes HTTPS calls to api.memoclaw.com.
+Use a dedicated wallet. The skill only makes HTTPS calls to api.memoclaw.dev.
 Free tier: 1000 calls per wallet. After that, USDC on Base required.
 </security>
 
@@ -666,6 +666,59 @@ DELETE /v1/memories/:id/relations/:relationId
 9. **Pin critical memories** — Use `pinned: true` for facts that should never decay (e.g. user's name)
 10. **Use relations** — Link related memories with `supersedes`, `contradicts`, `supports` for richer recall
 
+## Auto-Summarization Helpers
+
+Use these patterns to automatically summarize and store conversation context.
+
+### End-of-Session Summary
+
+After a meaningful conversation, generate a summary and store it:
+
+```bash
+# Ingest the full conversation — MemoClaw extracts, deduplicates, and relates facts
+memoclaw ingest "$(cat conversation.txt)" --namespace project-alpha
+
+# Or store a hand-crafted summary
+memoclaw store "Session 2026-02-13: Migrated auth to JWT, chose RS256, user wants refresh tokens by Friday" \
+  --importance 0.7 --tags session-summary --memory-type project --namespace project-alpha
+```
+
+### Periodic Consolidation (Recommended Weekly)
+
+```bash
+# Preview what would merge
+memoclaw consolidate --namespace default --dry-run
+
+# Merge duplicates (rule-based, fast)
+memoclaw consolidate --namespace default --mode rule
+
+# Merge duplicates (LLM-powered, smarter for nuanced overlaps)
+memoclaw consolidate --namespace default --mode llm
+```
+
+### Stale Memory Review
+
+```bash
+# Find high-importance memories that haven't been accessed recently
+memoclaw suggested --category stale --limit 10
+
+# Find memories that are decaying and may need pinning or refreshing
+memoclaw suggested --category decaying --limit 10
+```
+
+### Quick-Reference: Memory Type → Decay Half-Life
+
+| Type | Half-life | Pin if… |
+|------|-----------|---------|
+| `correction` | 180 days | It's a permanent constraint |
+| `preference` | 180 days | Core identity preference |
+| `decision` | 90 days | Architecture/design choice still active |
+| `project` | 30 days | Project is ongoing |
+| `observation` | 14 days | Rarely — observations are ephemeral |
+| `general` | 60 days | It's evergreen reference info |
+
+---
+
 ## Error Handling
 
 All errors follow this format:
@@ -693,14 +746,14 @@ import { x402Fetch } from '@x402/fetch';
 
 const memoclaw = {
   async store(content, options = {}) {
-    return x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
+    return x402Fetch('POST', 'https://api.memoclaw.dev/v1/store', {
       wallet: process.env.MEMOCLAW_PRIVATE_KEY,
       body: { content, ...options }
     });
   },
   
   async recall(query, options = {}) {
-    return x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+    return x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
       wallet: process.env.MEMOCLAW_PRIVATE_KEY,
       body: { query, ...options }
     });

--- a/.agents/skills/memoclaw/examples.md
+++ b/.agents/skills/memoclaw/examples.md
@@ -8,7 +8,7 @@ All examples use x402 for payment. Your wallet address becomes your identity.
 import { x402Fetch } from '@x402/fetch';
 
 // Store a preference (with optional TTL)
-await x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
+await x402Fetch('POST', 'https://api.memoclaw.dev/v1/store', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     content: "Ana prefers coffee without sugar, always in the morning",
@@ -19,7 +19,7 @@ await x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
 });
 
 // Recall it later
-const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+const result = await x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     query: "how does Ana like her coffee?",
@@ -35,7 +35,7 @@ console.log(result.memories[0].content);
 
 ```javascript
 // Store architecture decisions in a namespace
-await x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
+await x402Fetch('POST', 'https://api.memoclaw.dev/v1/store', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     content: "Team decided PostgreSQL over MongoDB for ACID requirements",
@@ -46,7 +46,7 @@ await x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
 });
 
 // Recall only from that project
-const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+const result = await x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     query: "what database did we choose and why?",
@@ -59,7 +59,7 @@ const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
 
 ```javascript
 // Import multiple memories at once ($0.01 for up to 100)
-await x402Fetch('POST', 'https://api.memoclaw.com/v1/store/batch', {
+await x402Fetch('POST', 'https://api.memoclaw.dev/v1/store/batch', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     memories: [
@@ -87,7 +87,7 @@ await x402Fetch('POST', 'https://api.memoclaw.com/v1/store/batch', {
 
 ```javascript
 // Recall only recent food preferences
-const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+const result = await x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     query: "food and drink preferences",
@@ -106,7 +106,7 @@ const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
 ```javascript
 // List all memories in a namespace
 const list = await x402Fetch('GET', 
-  'https://api.memoclaw.com/v1/memories?namespace=project-alpha&limit=50',
+  'https://api.memoclaw.dev/v1/memories?namespace=project-alpha&limit=50',
   { wallet: process.env.MEMOCLAW_PRIVATE_KEY }
 );
 
@@ -114,7 +114,7 @@ console.log(`Found ${list.total} memories`);
 
 // Update a memory (only provided fields change)
 await x402Fetch('PATCH',
-  `https://api.memoclaw.com/v1/memories/${memoryId}`,
+  `https://api.memoclaw.dev/v1/memories/${memoryId}`,
   {
     wallet: process.env.MEMOCLAW_PRIVATE_KEY,
     body: {
@@ -126,7 +126,7 @@ await x402Fetch('PATCH',
 
 // Set a TTL on a memory
 await x402Fetch('PATCH',
-  `https://api.memoclaw.com/v1/memories/${memoryId}`,
+  `https://api.memoclaw.dev/v1/memories/${memoryId}`,
   {
     wallet: process.env.MEMOCLAW_PRIVATE_KEY,
     body: { expires_at: "2026-06-01T00:00:00Z" }
@@ -135,7 +135,7 @@ await x402Fetch('PATCH',
 
 // Delete a specific memory
 await x402Fetch('DELETE',
-  `https://api.memoclaw.com/v1/memories/${memoryId}`,
+  `https://api.memoclaw.dev/v1/memories/${memoryId}`,
   { wallet: process.env.MEMOCLAW_PRIVATE_KEY }
 );
 ```
@@ -146,12 +146,12 @@ Using the x402 CLI directly:
 
 ```bash
 # Store a memory
-npx @x402/cli pay POST https://api.memoclaw.com/v1/store \
+npx @x402/cli pay POST https://api.memoclaw.dev/v1/store \
   --wallet ~/.wallet/key \
   --data '{"content": "User prefers vim keybindings", "importance": 0.8}'
 
 # Recall memories
-npx @x402/cli pay POST https://api.memoclaw.com/v1/recall \
+npx @x402/cli pay POST https://api.memoclaw.dev/v1/recall \
   --wallet ~/.wallet/key \
   --data '{"query": "editor preferences"}'
 ```
@@ -175,14 +175,14 @@ class AgentMemory {
       return existing.memories[0];
     }
     
-    return x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
+    return x402Fetch('POST', 'https://api.memoclaw.dev/v1/store', {
       wallet: this.wallet,
       body: { content, importance, metadata: { tags }, namespace: this.namespace }
     });
   }
 
   async recall(query, options = {}) {
-    return x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+    return x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
       wallet: this.wallet,
       body: { query, namespace: this.namespace, ...options }
     });

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Your wallet address is your identity — no signup needed.
 
 ## Links
 
-- **API**: https://api.memoclaw.com
-- **Docs**: https://memoclaw.com/docs
-- **Website**: https://memoclaw.com
+- **API**: https://api.memoclaw.dev
+- **Docs**: https://memoclaw.dev/docs
+- **Website**: https://memoclaw.dev
 
 ## License
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools:
 
 <security>
 This skill requires MEMOCLAW_PRIVATE_KEY environment variable for wallet auth.
-Use a dedicated wallet. The skill only makes HTTPS calls to api.memoclaw.com.
+Use a dedicated wallet. The skill only makes HTTPS calls to api.memoclaw.dev.
 Free tier: 1000 calls per wallet. After that, USDC on Base required.
 </security>
 
@@ -666,6 +666,59 @@ DELETE /v1/memories/:id/relations/:relationId
 9. **Pin critical memories** — Use `pinned: true` for facts that should never decay (e.g. user's name)
 10. **Use relations** — Link related memories with `supersedes`, `contradicts`, `supports` for richer recall
 
+## Auto-Summarization Helpers
+
+Use these patterns to automatically summarize and store conversation context.
+
+### End-of-Session Summary
+
+After a meaningful conversation, generate a summary and store it:
+
+```bash
+# Ingest the full conversation — MemoClaw extracts, deduplicates, and relates facts
+memoclaw ingest "$(cat conversation.txt)" --namespace project-alpha
+
+# Or store a hand-crafted summary
+memoclaw store "Session 2026-02-13: Migrated auth to JWT, chose RS256, user wants refresh tokens by Friday" \
+  --importance 0.7 --tags session-summary --memory-type project --namespace project-alpha
+```
+
+### Periodic Consolidation (Recommended Weekly)
+
+```bash
+# Preview what would merge
+memoclaw consolidate --namespace default --dry-run
+
+# Merge duplicates (rule-based, fast)
+memoclaw consolidate --namespace default --mode rule
+
+# Merge duplicates (LLM-powered, smarter for nuanced overlaps)
+memoclaw consolidate --namespace default --mode llm
+```
+
+### Stale Memory Review
+
+```bash
+# Find high-importance memories that haven't been accessed recently
+memoclaw suggested --category stale --limit 10
+
+# Find memories that are decaying and may need pinning or refreshing
+memoclaw suggested --category decaying --limit 10
+```
+
+### Quick-Reference: Memory Type → Decay Half-Life
+
+| Type | Half-life | Pin if… |
+|------|-----------|---------|
+| `correction` | 180 days | It's a permanent constraint |
+| `preference` | 180 days | Core identity preference |
+| `decision` | 90 days | Architecture/design choice still active |
+| `project` | 30 days | Project is ongoing |
+| `observation` | 14 days | Rarely — observations are ephemeral |
+| `general` | 60 days | It's evergreen reference info |
+
+---
+
 ## Error Handling
 
 All errors follow this format:
@@ -693,14 +746,14 @@ import { x402Fetch } from '@x402/fetch';
 
 const memoclaw = {
   async store(content, options = {}) {
-    return x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
+    return x402Fetch('POST', 'https://api.memoclaw.dev/v1/store', {
       wallet: process.env.MEMOCLAW_PRIVATE_KEY,
       body: { content, ...options }
     });
   },
   
   async recall(query, options = {}) {
-    return x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+    return x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
       wallet: process.env.MEMOCLAW_PRIVATE_KEY,
       body: { query, ...options }
     });

--- a/examples.md
+++ b/examples.md
@@ -8,7 +8,7 @@ All examples use x402 for payment. Your wallet address becomes your identity.
 import { x402Fetch } from '@x402/fetch';
 
 // Store a preference (with optional TTL)
-await x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
+await x402Fetch('POST', 'https://api.memoclaw.dev/v1/store', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     content: "Ana prefers coffee without sugar, always in the morning",
@@ -19,7 +19,7 @@ await x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
 });
 
 // Recall it later
-const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+const result = await x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     query: "how does Ana like her coffee?",
@@ -35,7 +35,7 @@ console.log(result.memories[0].content);
 
 ```javascript
 // Store architecture decisions in a namespace
-await x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
+await x402Fetch('POST', 'https://api.memoclaw.dev/v1/store', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     content: "Team decided PostgreSQL over MongoDB for ACID requirements",
@@ -46,7 +46,7 @@ await x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
 });
 
 // Recall only from that project
-const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+const result = await x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     query: "what database did we choose and why?",
@@ -59,7 +59,7 @@ const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
 
 ```javascript
 // Import multiple memories at once ($0.01 for up to 100)
-await x402Fetch('POST', 'https://api.memoclaw.com/v1/store/batch', {
+await x402Fetch('POST', 'https://api.memoclaw.dev/v1/store/batch', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     memories: [
@@ -87,7 +87,7 @@ await x402Fetch('POST', 'https://api.memoclaw.com/v1/store/batch', {
 
 ```javascript
 // Recall only recent food preferences
-const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+const result = await x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     query: "food and drink preferences",
@@ -106,7 +106,7 @@ const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
 ```javascript
 // List all memories in a namespace
 const list = await x402Fetch('GET', 
-  'https://api.memoclaw.com/v1/memories?namespace=project-alpha&limit=50',
+  'https://api.memoclaw.dev/v1/memories?namespace=project-alpha&limit=50',
   { wallet: process.env.MEMOCLAW_PRIVATE_KEY }
 );
 
@@ -114,7 +114,7 @@ console.log(`Found ${list.total} memories`);
 
 // Update a memory (only provided fields change)
 await x402Fetch('PATCH',
-  `https://api.memoclaw.com/v1/memories/${memoryId}`,
+  `https://api.memoclaw.dev/v1/memories/${memoryId}`,
   {
     wallet: process.env.MEMOCLAW_PRIVATE_KEY,
     body: {
@@ -126,7 +126,7 @@ await x402Fetch('PATCH',
 
 // Set a TTL on a memory
 await x402Fetch('PATCH',
-  `https://api.memoclaw.com/v1/memories/${memoryId}`,
+  `https://api.memoclaw.dev/v1/memories/${memoryId}`,
   {
     wallet: process.env.MEMOCLAW_PRIVATE_KEY,
     body: { expires_at: "2026-06-01T00:00:00Z" }
@@ -135,7 +135,7 @@ await x402Fetch('PATCH',
 
 // Delete a specific memory
 await x402Fetch('DELETE',
-  `https://api.memoclaw.com/v1/memories/${memoryId}`,
+  `https://api.memoclaw.dev/v1/memories/${memoryId}`,
   { wallet: process.env.MEMOCLAW_PRIVATE_KEY }
 );
 ```
@@ -146,12 +146,12 @@ Using the x402 CLI directly:
 
 ```bash
 # Store a memory
-npx @x402/cli pay POST https://api.memoclaw.com/v1/store \
+npx @x402/cli pay POST https://api.memoclaw.dev/v1/store \
   --wallet ~/.wallet/key \
   --data '{"content": "User prefers vim keybindings", "importance": 0.8}'
 
 # Recall memories
-npx @x402/cli pay POST https://api.memoclaw.com/v1/recall \
+npx @x402/cli pay POST https://api.memoclaw.dev/v1/recall \
   --wallet ~/.wallet/key \
   --data '{"query": "editor preferences"}'
 ```
@@ -175,14 +175,14 @@ class AgentMemory {
       return existing.memories[0];
     }
     
-    return x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
+    return x402Fetch('POST', 'https://api.memoclaw.dev/v1/store', {
       wallet: this.wallet,
       body: { content, importance, metadata: { tags }, namespace: this.namespace }
     });
   }
 
   async recall(query, options = {}) {
-    return x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+    return x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
       wallet: this.wallet,
       body: { query, namespace: this.namespace, ...options }
     });


### PR DESCRIPTION
## Changes

### Bug fixes
- **Wrong URLs**: All `memoclaw.com` → `memoclaw.dev` across SKILL.md, examples.md, README.md (37 occurrences)
- **Synced copies**: `.agents/skills/memoclaw/` files now match root files

### New features
- **Auto-summarization helpers** section in SKILL.md: end-of-session summary patterns, periodic consolidation guide, stale memory review
- **Quick-reference table**: memory type → decay half-life with pinning guidance

### Already present (no changes needed)
- Decision trees, importance scoring heuristics, namespace strategy, anti-patterns — all already comprehensive from recent updates
- Env var name (`MEMOCLAW_PRIVATE_KEY`) is correct throughout