### PR TITLE
feat: v1.4.0 — URL fixes, troubleshooting, competitor research

### DIFF
--- a/.agents/skills/memoclaw/SKILL.md
+++ b/.agents/skills/memoclaw/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memoclaw
-version: 1.3.0
+version: 1.4.0
 description: |
   Memory-as-a-Service for AI agents. Store and recall memories with semantic
   vector search. 1000 free calls per wallet, then x402 micropayments.
@@ -11,7 +11,7 @@ allowed-tools:
 
 <security>
 This skill requires MEMOCLAW_PRIVATE_KEY environment variable for wallet auth.
-Use a dedicated wallet. The skill only makes HTTPS calls to api.memoclaw.com.
+Use a dedicated wallet. The skill only makes HTTPS calls to api.memoclaw.dev.
 Free tier: 1000 calls per wallet. After that, USDC on Base required.
 </security>
 
@@ -666,6 +666,95 @@ DELETE /v1/memories/:id/relations/:relationId
 9. **Pin critical memories** — Use `pinned: true` for facts that should never decay (e.g. user's name)
 10. **Use relations** — Link related memories with `supersedes`, `contradicts`, `supports` for richer recall
 
+## Auto-Summarization Helpers
+
+Use these patterns to automatically summarize and store conversation context.
+
+### End-of-Session Summary
+
+After a meaningful conversation, generate a summary and store it:
+
+```bash
+# Ingest the full conversation — MemoClaw extracts, deduplicates, and relates facts
+memoclaw ingest "$(cat conversation.txt)" --namespace project-alpha
+
+# Or store a hand-crafted summary
+memoclaw store "Session 2026-02-13: Migrated auth to JWT, chose RS256, user wants refresh tokens by Friday" \
+  --importance 0.7 --tags session-summary --memory-type project --namespace project-alpha
+```
+
+### Periodic Consolidation (Recommended Weekly)
+
+```bash
+# Preview what would merge
+memoclaw consolidate --namespace default --dry-run
+
+# Merge duplicates (rule-based, fast)
+memoclaw consolidate --namespace default --mode rule
+
+# Merge duplicates (LLM-powered, smarter for nuanced overlaps)
+memoclaw consolidate --namespace default --mode llm
+```
+
+### Stale Memory Review
+
+```bash
+# Find high-importance memories that haven't been accessed recently
+memoclaw suggested --category stale --limit 10
+
+# Find memories that are decaying and may need pinning or refreshing
+memoclaw suggested --category decaying --limit 10
+```
+
+### Quick-Reference: Memory Type → Decay Half-Life
+
+| Type | Half-life | Pin if… |
+|------|-----------|---------|
+| `correction` | 180 days | It's a permanent constraint |
+| `preference` | 180 days | Core identity preference |
+| `decision` | 90 days | Architecture/design choice still active |
+| `project` | 30 days | Project is ongoing |
+| `observation` | 14 days | Rarely — observations are ephemeral |
+| `general` | 60 days | It's evergreen reference info |
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+**"PAYMENT_REQUIRED" on first call"**
+- Check `MEMOCLAW_PRIVATE_KEY` is set and starts with `0x`
+- Run `memoclaw status` to verify free tier remaining
+- Ensure the key is a valid Ethereum private key (64 hex chars after `0x`)
+
+**"Recall returns no results"**
+- Lower `min_similarity` (try 0.3-0.5 for broad matches)
+- Check you're querying the right `namespace`
+- Verify memories were stored (use `memoclaw list`)
+- Try rephrasing — semantic search matches meaning, not keywords
+
+**"Duplicate memories keep appearing"**
+- Always recall before storing (check the decision tree above)
+- Run `memoclaw consolidate --dry-run` to find clusters
+- Use higher `min_similarity` (0.85+) in consolidation
+
+**"Memories disappearing"**
+- Check `memory_type` — observations decay in 14 days
+- Pin important memories: `memoclaw update <id> --pinned true`
+- Check `expires_at` — expired memories are auto-removed
+
+**"CLI not found"**
+- Install: `npm install -g memoclaw`
+- Or use npx: `npx memoclaw status`
+
+### Getting Help
+
+- API docs: https://memoclaw.dev/docs
+- GitHub issues: https://github.com/anajuliabit/memoclaw-skill/issues
+
+---
+
 ## Error Handling
 
 All errors follow this format:
@@ -693,14 +782,14 @@ import { x402Fetch } from '@x402/fetch';
 
 const memoclaw = {
   async store(content, options = {}) {
-    return x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
+    return x402Fetch('POST', 'https://api.memoclaw.dev/v1/store', {
       wallet: process.env.MEMOCLAW_PRIVATE_KEY,
       body: { content, ...options }
     });
   },
   
   async recall(query, options = {}) {
-    return x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+    return x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
       wallet: process.env.MEMOCLAW_PRIVATE_KEY,
       body: { query, ...options }
     });

--- a/.agents/skills/memoclaw/examples.md
+++ b/.agents/skills/memoclaw/examples.md
@@ -8,7 +8,7 @@ All examples use x402 for payment. Your wallet address becomes your identity.
 import { x402Fetch } from '@x402/fetch';
 
 // Store a preference (with optional TTL)
-await x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
+await x402Fetch('POST', 'https://api.memoclaw.dev/v1/store', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     content: "Ana prefers coffee without sugar, always in the morning",
@@ -19,7 +19,7 @@ await x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
 });
 
 // Recall it later
-const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+const result = await x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     query: "how does Ana like her coffee?",
@@ -35,7 +35,7 @@ console.log(result.memories[0].content);
 
 ```javascript
 // Store architecture decisions in a namespace
-await x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
+await x402Fetch('POST', 'https://api.memoclaw.dev/v1/store', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     content: "Team decided PostgreSQL over MongoDB for ACID requirements",
@@ -46,7 +46,7 @@ await x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
 });
 
 // Recall only from that project
-const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+const result = await x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     query: "what database did we choose and why?",
@@ -59,7 +59,7 @@ const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
 
 ```javascript
 // Import multiple memories at once ($0.01 for up to 100)
-await x402Fetch('POST', 'https://api.memoclaw.com/v1/store/batch', {
+await x402Fetch('POST', 'https://api.memoclaw.dev/v1/store/batch', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     memories: [
@@ -87,7 +87,7 @@ await x402Fetch('POST', 'https://api.memoclaw.com/v1/store/batch', {
 
 ```javascript
 // Recall only recent food preferences
-const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+const result = await x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     query: "food and drink preferences",
@@ -106,7 +106,7 @@ const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
 ```javascript
 // List all memories in a namespace
 const list = await x402Fetch('GET', 
-  'https://api.memoclaw.com/v1/memories?namespace=project-alpha&limit=50',
+  'https://api.memoclaw.dev/v1/memories?namespace=project-alpha&limit=50',
   { wallet: process.env.MEMOCLAW_PRIVATE_KEY }
 );
 
@@ -114,7 +114,7 @@ console.log(`Found ${list.total} memories`);
 
 // Update a memory (only provided fields change)
 await x402Fetch('PATCH',
-  `https://api.memoclaw.com/v1/memories/${memoryId}`,
+  `https://api.memoclaw.dev/v1/memories/${memoryId}`,
   {
     wallet: process.env.MEMOCLAW_PRIVATE_KEY,
     body: {
@@ -126,7 +126,7 @@ await x402Fetch('PATCH',
 
 // Set a TTL on a memory
 await x402Fetch('PATCH',
-  `https://api.memoclaw.com/v1/memories/${memoryId}`,
+  `https://api.memoclaw.dev/v1/memories/${memoryId}`,
   {
     wallet: process.env.MEMOCLAW_PRIVATE_KEY,
     body: { expires_at: "2026-06-01T00:00:00Z" }
@@ -135,7 +135,7 @@ await x402Fetch('PATCH',
 
 // Delete a specific memory
 await x402Fetch('DELETE',
-  `https://api.memoclaw.com/v1/memories/${memoryId}`,
+  `https://api.memoclaw.dev/v1/memories/${memoryId}`,
   { wallet: process.env.MEMOCLAW_PRIVATE_KEY }
 );
 ```
@@ -146,12 +146,12 @@ Using the x402 CLI directly:
 
 ```bash
 # Store a memory
-npx @x402/cli pay POST https://api.memoclaw.com/v1/store \
+npx @x402/cli pay POST https://api.memoclaw.dev/v1/store \
   --wallet ~/.wallet/key \
   --data '{"content": "User prefers vim keybindings", "importance": 0.8}'
 
 # Recall memories
-npx @x402/cli pay POST https://api.memoclaw.com/v1/recall \
+npx @x402/cli pay POST https://api.memoclaw.dev/v1/recall \
   --wallet ~/.wallet/key \
   --data '{"query": "editor preferences"}'
 ```
@@ -175,14 +175,14 @@ class AgentMemory {
       return existing.memories[0];
     }
     
-    return x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
+    return x402Fetch('POST', 'https://api.memoclaw.dev/v1/store', {
       wallet: this.wallet,
       body: { content, importance, metadata: { tags }, namespace: this.namespace }
     });
   }
 
   async recall(query, options = {}) {
-    return x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+    return x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
       wallet: this.wallet,
       body: { query, namespace: this.namespace, ...options }
     });

--- a/COMPETITORS.md
+++ b/COMPETITORS.md
@@ -1,0 +1,55 @@
+# MemoClaw — Competitive Landscape (Feb 2026)
+
+## Quick Comparison
+
+| Feature | **MemoClaw** | **Mem0** | **Zep** |
+|---------|-------------|----------|---------|
+| **Auth model** | Wallet-based (no signup) | API key + account | API key + account |
+| **Payment** | x402 micropayments / free tier | Subscription plans | Subscription plans |
+| **Free tier** | 1000 calls/wallet | Limited free plan | Limited free plan |
+| **Identity** | Wallet address | user_id string | user_id string |
+| **Search** | Semantic vector search | Semantic + graph | Temporal knowledge graph |
+| **Memory decay** | Type-based half-lives | No native decay | Temporal invalidation |
+| **Relations** | Explicit (supersedes, contradicts, etc.) | Auto-extracted | Auto graph edges |
+| **Consolidation** | Rule-based + LLM merge | Auto-dedup | Auto via graph |
+| **Self-hosted** | No (SaaS only) | Yes (OSS option) | Yes (OSS option) |
+| **SDK languages** | JS/TS (CLI + x402Fetch) | Python, JS, REST | Python, JS, REST |
+| **Graph memory** | No (flat + relations) | Yes (knowledge graph) | Yes (temporal graph) |
+| **MCP support** | Not yet | Yes | Yes |
+| **SOC 2 / GDPR** | Not advertised | SOC 2 Type II | Enterprise tier |
+| **Multimodal** | Text only | Text + images | Text only |
+| **Pricing model** | Pay-per-call ($0.001) | Seat/usage plans | Seat/usage plans |
+
+## MemoClaw Differentiators
+
+1. **Zero-signup onboarding** — wallet address = identity. No accounts, no API keys, no email verification. Unique in the market.
+2. **Micropayment model** — pay exactly for what you use via x402. No monthly minimums.
+3. **Generous free tier** — 1000 calls free per wallet, no credit card.
+4. **Memory decay system** — type-based half-lives with pinning. Neither Mem0 nor Zep has this natively.
+5. **Crypto-native** — built for the on-chain agent ecosystem (x402, USDC on Base).
+
+## Where Competitors Are Ahead
+
+1. **Graph memory** — Both Mem0 and Zep offer knowledge graphs that auto-extract entities and relationships. MemoClaw's flat-with-relations model is simpler but less powerful for complex reasoning.
+2. **Self-hosted option** — Both competitors offer open-source self-hosted versions. MemoClaw is SaaS-only.
+3. **MCP integration** — Mem0 has an MCP server, making it plug-and-play with Claude Desktop and similar tools.
+4. **Enterprise compliance** — Mem0 has SOC 2 Type II. Important for enterprise adoption.
+5. **Multi-language SDKs** — Mem0 has Python + JS SDKs. MemoClaw is JS/CLI only.
+6. **Multimodal** — Mem0 supports image memories.
+
+## Opportunities
+
+- **MCP server** — Adding an MCP server would make MemoClaw compatible with Claude Desktop, Cursor, and other MCP clients. Low effort, high impact.
+- **Python SDK** — Many AI agents are Python-based. A Python client would expand reach significantly.
+- **Graph layer** — Even a simple entity extraction layer on top of existing relations would close the gap with Mem0/Zep.
+- **Self-hosted tier** — Even a Docker-based single-node option would appeal to privacy-conscious users.
+
+## Target Audience Fit
+
+| Audience | Best fit |
+|----------|----------|
+| Crypto/web3 agents | **MemoClaw** (wallet-native, x402) |
+| Enterprise chatbots | Mem0 or Zep (compliance, scale) |
+| Hobbyist/indie devs | **MemoClaw** (free tier, no signup) |
+| Python ML pipelines | Mem0 (Python SDK, OSS) |
+| Complex multi-entity reasoning | Zep (temporal graph) |

--- a/README.md
+++ b/README.md
@@ -41,9 +41,13 @@ Your wallet address is your identity — no signup needed.
 
 ## Links
 
-- **API**: https://api.memoclaw.com
-- **Docs**: https://memoclaw.com/docs
-- **Website**: https://memoclaw.com
+- **API**: https://api.memoclaw.dev
+- **Docs**: https://memoclaw.dev/docs
+- **Website**: https://memoclaw.dev
+
+## Comparison with Alternatives
+
+See [COMPETITORS.md](COMPETITORS.md) for a detailed comparison with Mem0, Zep, and others.
 
 ## License
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memoclaw
-version: 1.3.0
+version: 1.4.0
 description: |
   Memory-as-a-Service for AI agents. Store and recall memories with semantic
   vector search. 1000 free calls per wallet, then x402 micropayments.
@@ -11,7 +11,7 @@ allowed-tools:
 
 <security>
 This skill requires MEMOCLAW_PRIVATE_KEY environment variable for wallet auth.
-Use a dedicated wallet. The skill only makes HTTPS calls to api.memoclaw.com.
+Use a dedicated wallet. The skill only makes HTTPS calls to api.memoclaw.dev.
 Free tier: 1000 calls per wallet. After that, USDC on Base required.
 </security>
 
@@ -666,6 +666,95 @@ DELETE /v1/memories/:id/relations/:relationId
 9. **Pin critical memories** — Use `pinned: true` for facts that should never decay (e.g. user's name)
 10. **Use relations** — Link related memories with `supersedes`, `contradicts`, `supports` for richer recall
 
+## Auto-Summarization Helpers
+
+Use these patterns to automatically summarize and store conversation context.
+
+### End-of-Session Summary
+
+After a meaningful conversation, generate a summary and store it:
+
+```bash
+# Ingest the full conversation — MemoClaw extracts, deduplicates, and relates facts
+memoclaw ingest "$(cat conversation.txt)" --namespace project-alpha
+
+# Or store a hand-crafted summary
+memoclaw store "Session 2026-02-13: Migrated auth to JWT, chose RS256, user wants refresh tokens by Friday" \
+  --importance 0.7 --tags session-summary --memory-type project --namespace project-alpha
+```
+
+### Periodic Consolidation (Recommended Weekly)
+
+```bash
+# Preview what would merge
+memoclaw consolidate --namespace default --dry-run
+
+# Merge duplicates (rule-based, fast)
+memoclaw consolidate --namespace default --mode rule
+
+# Merge duplicates (LLM-powered, smarter for nuanced overlaps)
+memoclaw consolidate --namespace default --mode llm
+```
+
+### Stale Memory Review
+
+```bash
+# Find high-importance memories that haven't been accessed recently
+memoclaw suggested --category stale --limit 10
+
+# Find memories that are decaying and may need pinning or refreshing
+memoclaw suggested --category decaying --limit 10
+```
+
+### Quick-Reference: Memory Type → Decay Half-Life
+
+| Type | Half-life | Pin if… |
+|------|-----------|---------|
+| `correction` | 180 days | It's a permanent constraint |
+| `preference` | 180 days | Core identity preference |
+| `decision` | 90 days | Architecture/design choice still active |
+| `project` | 30 days | Project is ongoing |
+| `observation` | 14 days | Rarely — observations are ephemeral |
+| `general` | 60 days | It's evergreen reference info |
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+**"PAYMENT_REQUIRED" on first call"**
+- Check `MEMOCLAW_PRIVATE_KEY` is set and starts with `0x`
+- Run `memoclaw status` to verify free tier remaining
+- Ensure the key is a valid Ethereum private key (64 hex chars after `0x`)
+
+**"Recall returns no results"**
+- Lower `min_similarity` (try 0.3-0.5 for broad matches)
+- Check you're querying the right `namespace`
+- Verify memories were stored (use `memoclaw list`)
+- Try rephrasing — semantic search matches meaning, not keywords
+
+**"Duplicate memories keep appearing"**
+- Always recall before storing (check the decision tree above)
+- Run `memoclaw consolidate --dry-run` to find clusters
+- Use higher `min_similarity` (0.85+) in consolidation
+
+**"Memories disappearing"**
+- Check `memory_type` — observations decay in 14 days
+- Pin important memories: `memoclaw update <id> --pinned true`
+- Check `expires_at` — expired memories are auto-removed
+
+**"CLI not found"**
+- Install: `npm install -g memoclaw`
+- Or use npx: `npx memoclaw status`
+
+### Getting Help
+
+- API docs: https://memoclaw.dev/docs
+- GitHub issues: https://github.com/anajuliabit/memoclaw-skill/issues
+
+---
+
 ## Error Handling
 
 All errors follow this format:
@@ -693,14 +782,14 @@ import { x402Fetch } from '@x402/fetch';
 
 const memoclaw = {
   async store(content, options = {}) {
-    return x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
+    return x402Fetch('POST', 'https://api.memoclaw.dev/v1/store', {
       wallet: process.env.MEMOCLAW_PRIVATE_KEY,
       body: { content, ...options }
     });
   },
   
   async recall(query, options = {}) {
-    return x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+    return x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
       wallet: process.env.MEMOCLAW_PRIVATE_KEY,
       body: { query, ...options }
     });

--- a/examples.md
+++ b/examples.md
@@ -8,7 +8,7 @@ All examples use x402 for payment. Your wallet address becomes your identity.
 import { x402Fetch } from '@x402/fetch';
 
 // Store a preference (with optional TTL)
-await x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
+await x402Fetch('POST', 'https://api.memoclaw.dev/v1/store', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     content: "Ana prefers coffee without sugar, always in the morning",
@@ -19,7 +19,7 @@ await x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
 });
 
 // Recall it later
-const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+const result = await x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     query: "how does Ana like her coffee?",
@@ -35,7 +35,7 @@ console.log(result.memories[0].content);
 
 ```javascript
 // Store architecture decisions in a namespace
-await x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
+await x402Fetch('POST', 'https://api.memoclaw.dev/v1/store', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     content: "Team decided PostgreSQL over MongoDB for ACID requirements",
@@ -46,7 +46,7 @@ await x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
 });
 
 // Recall only from that project
-const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+const result = await x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     query: "what database did we choose and why?",
@@ -59,7 +59,7 @@ const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
 
 ```javascript
 // Import multiple memories at once ($0.01 for up to 100)
-await x402Fetch('POST', 'https://api.memoclaw.com/v1/store/batch', {
+await x402Fetch('POST', 'https://api.memoclaw.dev/v1/store/batch', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     memories: [
@@ -87,7 +87,7 @@ await x402Fetch('POST', 'https://api.memoclaw.com/v1/store/batch', {
 
 ```javascript
 // Recall only recent food preferences
-const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+const result = await x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     query: "food and drink preferences",
@@ -106,7 +106,7 @@ const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
 ```javascript
 // List all memories in a namespace
 const list = await x402Fetch('GET', 
-  'https://api.memoclaw.com/v1/memories?namespace=project-alpha&limit=50',
+  'https://api.memoclaw.dev/v1/memories?namespace=project-alpha&limit=50',
   { wallet: process.env.MEMOCLAW_PRIVATE_KEY }
 );
 
@@ -114,7 +114,7 @@ console.log(`Found ${list.total} memories`);
 
 // Update a memory (only provided fields change)
 await x402Fetch('PATCH',
-  `https://api.memoclaw.com/v1/memories/${memoryId}`,
+  `https://api.memoclaw.dev/v1/memories/${memoryId}`,
   {
     wallet: process.env.MEMOCLAW_PRIVATE_KEY,
     body: {
@@ -126,7 +126,7 @@ await x402Fetch('PATCH',
 
 // Set a TTL on a memory
 await x402Fetch('PATCH',
-  `https://api.memoclaw.com/v1/memories/${memoryId}`,
+  `https://api.memoclaw.dev/v1/memories/${memoryId}`,
   {
     wallet: process.env.MEMOCLAW_PRIVATE_KEY,
     body: { expires_at: "2026-06-01T00:00:00Z" }
@@ -135,7 +135,7 @@ await x402Fetch('PATCH',
 
 // Delete a specific memory
 await x402Fetch('DELETE',
-  `https://api.memoclaw.com/v1/memories/${memoryId}`,
+  `https://api.memoclaw.dev/v1/memories/${memoryId}`,
   { wallet: process.env.MEMOCLAW_PRIVATE_KEY }
 );
 ```
@@ -146,12 +146,12 @@ Using the x402 CLI directly:
 
 ```bash
 # Store a memory
-npx @x402/cli pay POST https://api.memoclaw.com/v1/store \
+npx @x402/cli pay POST https://api.memoclaw.dev/v1/store \
   --wallet ~/.wallet/key \
   --data '{"content": "User prefers vim keybindings", "importance": 0.8}'
 
 # Recall memories
-npx @x402/cli pay POST https://api.memoclaw.com/v1/recall \
+npx @x402/cli pay POST https://api.memoclaw.dev/v1/recall \
   --wallet ~/.wallet/key \
   --data '{"query": "editor preferences"}'
 ```
@@ -175,14 +175,14 @@ class AgentMemory {
       return existing.memories[0];
     }
     
-    return x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
+    return x402Fetch('POST', 'https://api.memoclaw.dev/v1/store', {
       wallet: this.wallet,
       body: { content, importance, metadata: { tags }, namespace: this.namespace }
     });
   }
 
   async recall(query, options = {}) {
-    return x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+    return x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
       wallet: this.wallet,
       body: { query, namespace: this.namespace, ...options }
     });


### PR DESCRIPTION
## Changes

### Bug Fixes
- Fix all `memoclaw.com` → `memoclaw.dev` URLs across SKILL.md, examples.md, README.md (same as #9, included here for completeness)

### SKILL.md Improvements
- **Auto-summarization helpers**: End-of-session summary patterns, periodic consolidation, stale memory review
- **Troubleshooting section**: Common issues (payment errors, empty recalls, duplicates, decay, CLI setup) with solutions
- **Decay half-life quick-reference table**: Easy lookup for memory type → half-life → when to pin
- Version bump to 1.4.0

### New Files
- **COMPETITORS.md**: Detailed comparison with Mem0 and Zep covering features, pricing, target audience, and opportunities (MCP server, Python SDK, graph layer, self-hosted option)

### Housekeeping
- Synced `.agents/skills/memoclaw/` with root files

> Note: PR #9 covers the URL fixes subset. This PR is a superset — if this merges first, #9 can be closed.