### PR TITLE
feat: v1.5.0 — status docs, error recovery, migration guide, multi-agent patterns

### DIFF
--- a/.agents/skills/memoclaw/SKILL.md
+++ b/.agents/skills/memoclaw/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memoclaw
-version: 1.3.0
+version: 1.5.0
 description: |
   Memory-as-a-Service for AI agents. Store and recall memories with semantic
   vector search. 1000 free calls per wallet, then x402 micropayments.
@@ -11,7 +11,7 @@ allowed-tools:
 
 <security>
 This skill requires MEMOCLAW_PRIVATE_KEY environment variable for wallet auth.
-Use a dedicated wallet. The skill only makes HTTPS calls to api.memoclaw.com.
+Use a dedicated wallet. The skill only makes HTTPS calls to api.memoclaw.dev.
 Free tier: 1000 calls per wallet. After that, USDC on Base required.
 </security>
 
@@ -39,11 +39,13 @@ Is the information worth remembering across sessions?
       ├─ YES → Is the existing memory outdated?
       │  ├─ YES → Update the existing memory (PATCH).
       │  └─ NO → Skip. Don't duplicate.
-      └─ NO → Store it.
-         ├─ User preference/correction → importance 0.8-0.95
-         ├─ Decision or architecture → importance 0.85-0.95
-         ├─ Factual context → importance 0.5-0.8
-         └─ Ephemeral observation → importance 0.3-0.5 (or skip)
+      └─ NO → How much information?
+         ├─ Single fact → Store it.
+         │  ├─ User preference/correction → importance 0.8-0.95
+         │  ├─ Decision or architecture → importance 0.85-0.95
+         │  ├─ Factual context → importance 0.5-0.8
+         │  └─ Ephemeral observation → importance 0.3-0.5 (or skip)
+         └─ Multiple facts / raw conversation → Use `ingest` (auto-extract + dedup)
 ```
 
 ### When MemoClaw Beats Local Files
@@ -693,14 +695,14 @@ import { x402Fetch } from '@x402/fetch';
 
 const memoclaw = {
   async store(content, options = {}) {
-    return x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
+    return x402Fetch('POST', 'https://api.memoclaw.dev/v1/store', {
       wallet: process.env.MEMOCLAW_PRIVATE_KEY,
       body: { content, ...options }
     });
   },
   
   async recall(query, options = {}) {
-    return x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+    return x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
       wallet: process.env.MEMOCLAW_PRIVATE_KEY,
       body: { query, ...options }
     });
@@ -717,3 +719,103 @@ await memoclaw.store("User's timezone is America/Sao_Paulo", {
 // Recall later
 const results = await memoclaw.recall("what timezone is the user in?");
 ```
+
+---
+
+## Status Check
+
+```
+GET /v1/status
+```
+
+Returns wallet info and free tier usage. No payment required.
+
+Response:
+```json
+{
+  "wallet": "0xYourAddress",
+  "free_calls_remaining": 847,
+  "free_calls_total": 1000,
+  "plan": "free"
+}
+```
+
+CLI: `memoclaw status`
+
+---
+
+## Error Recovery & Retry
+
+When MemoClaw API calls fail, follow this strategy:
+
+```
+API call failed?
+├─ 402 PAYMENT_REQUIRED
+│  ├─ Free tier? → Check MEMOCLAW_PRIVATE_KEY, run `memoclaw status`
+│  └─ Paid tier? → Check USDC balance on Base
+├─ 422 VALIDATION_ERROR → Fix request body (check field constraints above)
+├─ 404 NOT_FOUND → Memory was deleted or never existed
+├─ 429 RATE_LIMITED → Back off 2-5 seconds, retry once
+├─ 500/502/503 → Retry with exponential backoff (1s, 2s, 4s), max 3 retries
+└─ Network error → Fall back to local files temporarily, retry next session
+```
+
+**Graceful degradation:** If MemoClaw is unreachable, don't block the user. Use local scratch files as temporary storage and sync back when the API is available. Never let a memory service outage prevent you from helping.
+
+---
+
+## Migration Guide: Local Files → MemoClaw
+
+If you've been using local markdown files (e.g., `MEMORY.md`, `memory/*.md`) for persistence, here's how to migrate:
+
+### Step 1: Extract facts from existing files
+
+```bash
+# Feed your existing memory file to ingest
+memoclaw ingest "$(cat MEMORY.md)" --namespace default
+
+# Or for multiple files
+for f in memory/*.md; do
+  memoclaw ingest "$(cat "$f")" --namespace default
+done
+```
+
+### Step 2: Verify migration
+
+```bash
+# Check what was stored
+memoclaw list --limit 50
+
+# Test recall
+memoclaw recall "user preferences"
+```
+
+### Step 3: Pin critical memories
+
+```bash
+# Find your most important memories and pin them
+memoclaw suggested --category hot --limit 20
+# Then pin the essentials:
+memoclaw update <id> --pinned true
+```
+
+### Step 4: Keep local files as backup
+
+Don't delete local files immediately. Run both systems in parallel for a week, then phase out local files once you trust the recall quality.
+
+---
+
+## Multi-Agent Patterns
+
+When multiple agents share the same wallet but need isolation:
+
+```bash
+# Agent 1 stores in its own scope
+memoclaw store "User prefers concise answers" \
+  --agent-id agent-main --session-id session-abc
+
+# Agent 2 can query across all agents or filter
+memoclaw recall "user communication style" --agent-id agent-main
+```
+
+Use `agent_id` for per-agent isolation and `session_id` for per-conversation scoping. Namespaces are for logical domains (projects), not agents.

--- a/.agents/skills/memoclaw/examples.md
+++ b/.agents/skills/memoclaw/examples.md
@@ -8,7 +8,7 @@ All examples use x402 for payment. Your wallet address becomes your identity.
 import { x402Fetch } from '@x402/fetch';
 
 // Store a preference (with optional TTL)
-await x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
+await x402Fetch('POST', 'https://api.memoclaw.dev/v1/store', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     content: "Ana prefers coffee without sugar, always in the morning",
@@ -19,7 +19,7 @@ await x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
 });
 
 // Recall it later
-const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+const result = await x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     query: "how does Ana like her coffee?",
@@ -35,7 +35,7 @@ console.log(result.memories[0].content);
 
 ```javascript
 // Store architecture decisions in a namespace
-await x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
+await x402Fetch('POST', 'https://api.memoclaw.dev/v1/store', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     content: "Team decided PostgreSQL over MongoDB for ACID requirements",
@@ -46,7 +46,7 @@ await x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
 });
 
 // Recall only from that project
-const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+const result = await x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     query: "what database did we choose and why?",
@@ -59,7 +59,7 @@ const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
 
 ```javascript
 // Import multiple memories at once ($0.01 for up to 100)
-await x402Fetch('POST', 'https://api.memoclaw.com/v1/store/batch', {
+await x402Fetch('POST', 'https://api.memoclaw.dev/v1/store/batch', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     memories: [
@@ -87,7 +87,7 @@ await x402Fetch('POST', 'https://api.memoclaw.com/v1/store/batch', {
 
 ```javascript
 // Recall only recent food preferences
-const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+const result = await x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     query: "food and drink preferences",
@@ -106,7 +106,7 @@ const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
 ```javascript
 // List all memories in a namespace
 const list = await x402Fetch('GET', 
-  'https://api.memoclaw.com/v1/memories?namespace=project-alpha&limit=50',
+  'https://api.memoclaw.dev/v1/memories?namespace=project-alpha&limit=50',
   { wallet: process.env.MEMOCLAW_PRIVATE_KEY }
 );
 
@@ -114,7 +114,7 @@ console.log(`Found ${list.total} memories`);
 
 // Update a memory (only provided fields change)
 await x402Fetch('PATCH',
-  `https://api.memoclaw.com/v1/memories/${memoryId}`,
+  `https://api.memoclaw.dev/v1/memories/${memoryId}`,
   {
     wallet: process.env.MEMOCLAW_PRIVATE_KEY,
     body: {
@@ -126,7 +126,7 @@ await x402Fetch('PATCH',
 
 // Set a TTL on a memory
 await x402Fetch('PATCH',
-  `https://api.memoclaw.com/v1/memories/${memoryId}`,
+  `https://api.memoclaw.dev/v1/memories/${memoryId}`,
   {
     wallet: process.env.MEMOCLAW_PRIVATE_KEY,
     body: { expires_at: "2026-06-01T00:00:00Z" }
@@ -135,7 +135,7 @@ await x402Fetch('PATCH',
 
 // Delete a specific memory
 await x402Fetch('DELETE',
-  `https://api.memoclaw.com/v1/memories/${memoryId}`,
+  `https://api.memoclaw.dev/v1/memories/${memoryId}`,
   { wallet: process.env.MEMOCLAW_PRIVATE_KEY }
 );
 ```
@@ -146,12 +146,12 @@ Using the x402 CLI directly:
 
 ```bash
 # Store a memory
-npx @x402/cli pay POST https://api.memoclaw.com/v1/store \
+npx @x402/cli pay POST https://api.memoclaw.dev/v1/store \
   --wallet ~/.wallet/key \
   --data '{"content": "User prefers vim keybindings", "importance": 0.8}'
 
 # Recall memories
-npx @x402/cli pay POST https://api.memoclaw.com/v1/recall \
+npx @x402/cli pay POST https://api.memoclaw.dev/v1/recall \
   --wallet ~/.wallet/key \
   --data '{"query": "editor preferences"}'
 ```
@@ -175,14 +175,14 @@ class AgentMemory {
       return existing.memories[0];
     }
     
-    return x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
+    return x402Fetch('POST', 'https://api.memoclaw.dev/v1/store', {
       wallet: this.wallet,
       body: { content, importance, metadata: { tags }, namespace: this.namespace }
     });
   }
 
   async recall(query, options = {}) {
-    return x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+    return x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
       wallet: this.wallet,
       body: { query, namespace: this.namespace, ...options }
     });

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+.env.*
+!.env.example

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Your wallet address is your identity — no signup needed.
 
 ## Links
 
-- **API**: https://api.memoclaw.com
-- **Docs**: https://memoclaw.com/docs
-- **Website**: https://memoclaw.com
+- **API**: https://api.memoclaw.dev
+- **Docs**: https://memoclaw.dev/docs
+- **Website**: https://memoclaw.dev
 
 ## License
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memoclaw
-version: 1.3.0
+version: 1.5.0
 description: |
   Memory-as-a-Service for AI agents. Store and recall memories with semantic
   vector search. 1000 free calls per wallet, then x402 micropayments.
@@ -11,7 +11,7 @@ allowed-tools:
 
 <security>
 This skill requires MEMOCLAW_PRIVATE_KEY environment variable for wallet auth.
-Use a dedicated wallet. The skill only makes HTTPS calls to api.memoclaw.com.
+Use a dedicated wallet. The skill only makes HTTPS calls to api.memoclaw.dev.
 Free tier: 1000 calls per wallet. After that, USDC on Base required.
 </security>
 
@@ -39,11 +39,13 @@ Is the information worth remembering across sessions?
       ├─ YES → Is the existing memory outdated?
       │  ├─ YES → Update the existing memory (PATCH).
       │  └─ NO → Skip. Don't duplicate.
-      └─ NO → Store it.
-         ├─ User preference/correction → importance 0.8-0.95
-         ├─ Decision or architecture → importance 0.85-0.95
-         ├─ Factual context → importance 0.5-0.8
-         └─ Ephemeral observation → importance 0.3-0.5 (or skip)
+      └─ NO → How much information?
+         ├─ Single fact → Store it.
+         │  ├─ User preference/correction → importance 0.8-0.95
+         │  ├─ Decision or architecture → importance 0.85-0.95
+         │  ├─ Factual context → importance 0.5-0.8
+         │  └─ Ephemeral observation → importance 0.3-0.5 (or skip)
+         └─ Multiple facts / raw conversation → Use `ingest` (auto-extract + dedup)
 ```
 
 ### When MemoClaw Beats Local Files
@@ -693,14 +695,14 @@ import { x402Fetch } from '@x402/fetch';
 
 const memoclaw = {
   async store(content, options = {}) {
-    return x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
+    return x402Fetch('POST', 'https://api.memoclaw.dev/v1/store', {
       wallet: process.env.MEMOCLAW_PRIVATE_KEY,
       body: { content, ...options }
     });
   },
   
   async recall(query, options = {}) {
-    return x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+    return x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
       wallet: process.env.MEMOCLAW_PRIVATE_KEY,
       body: { query, ...options }
     });
@@ -717,3 +719,103 @@ await memoclaw.store("User's timezone is America/Sao_Paulo", {
 // Recall later
 const results = await memoclaw.recall("what timezone is the user in?");
 ```
+
+---
+
+## Status Check
+
+```
+GET /v1/status
+```
+
+Returns wallet info and free tier usage. No payment required.
+
+Response:
+```json
+{
+  "wallet": "0xYourAddress",
+  "free_calls_remaining": 847,
+  "free_calls_total": 1000,
+  "plan": "free"
+}
+```
+
+CLI: `memoclaw status`
+
+---
+
+## Error Recovery & Retry
+
+When MemoClaw API calls fail, follow this strategy:
+
+```
+API call failed?
+├─ 402 PAYMENT_REQUIRED
+│  ├─ Free tier? → Check MEMOCLAW_PRIVATE_KEY, run `memoclaw status`
+│  └─ Paid tier? → Check USDC balance on Base
+├─ 422 VALIDATION_ERROR → Fix request body (check field constraints above)
+├─ 404 NOT_FOUND → Memory was deleted or never existed
+├─ 429 RATE_LIMITED → Back off 2-5 seconds, retry once
+├─ 500/502/503 → Retry with exponential backoff (1s, 2s, 4s), max 3 retries
+└─ Network error → Fall back to local files temporarily, retry next session
+```
+
+**Graceful degradation:** If MemoClaw is unreachable, don't block the user. Use local scratch files as temporary storage and sync back when the API is available. Never let a memory service outage prevent you from helping.
+
+---
+
+## Migration Guide: Local Files → MemoClaw
+
+If you've been using local markdown files (e.g., `MEMORY.md`, `memory/*.md`) for persistence, here's how to migrate:
+
+### Step 1: Extract facts from existing files
+
+```bash
+# Feed your existing memory file to ingest
+memoclaw ingest "$(cat MEMORY.md)" --namespace default
+
+# Or for multiple files
+for f in memory/*.md; do
+  memoclaw ingest "$(cat "$f")" --namespace default
+done
+```
+
+### Step 2: Verify migration
+
+```bash
+# Check what was stored
+memoclaw list --limit 50
+
+# Test recall
+memoclaw recall "user preferences"
+```
+
+### Step 3: Pin critical memories
+
+```bash
+# Find your most important memories and pin them
+memoclaw suggested --category hot --limit 20
+# Then pin the essentials:
+memoclaw update <id> --pinned true
+```
+
+### Step 4: Keep local files as backup
+
+Don't delete local files immediately. Run both systems in parallel for a week, then phase out local files once you trust the recall quality.
+
+---
+
+## Multi-Agent Patterns
+
+When multiple agents share the same wallet but need isolation:
+
+```bash
+# Agent 1 stores in its own scope
+memoclaw store "User prefers concise answers" \
+  --agent-id agent-main --session-id session-abc
+
+# Agent 2 can query across all agents or filter
+memoclaw recall "user communication style" --agent-id agent-main
+```
+
+Use `agent_id` for per-agent isolation and `session_id` for per-conversation scoping. Namespaces are for logical domains (projects), not agents.

--- a/examples.md
+++ b/examples.md
@@ -8,7 +8,7 @@ All examples use x402 for payment. Your wallet address becomes your identity.
 import { x402Fetch } from '@x402/fetch';
 
 // Store a preference (with optional TTL)
-await x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
+await x402Fetch('POST', 'https://api.memoclaw.dev/v1/store', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     content: "Ana prefers coffee without sugar, always in the morning",
@@ -19,7 +19,7 @@ await x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
 });
 
 // Recall it later
-const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+const result = await x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     query: "how does Ana like her coffee?",
@@ -35,7 +35,7 @@ console.log(result.memories[0].content);
 
 ```javascript
 // Store architecture decisions in a namespace
-await x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
+await x402Fetch('POST', 'https://api.memoclaw.dev/v1/store', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     content: "Team decided PostgreSQL over MongoDB for ACID requirements",
@@ -46,7 +46,7 @@ await x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
 });
 
 // Recall only from that project
-const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+const result = await x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     query: "what database did we choose and why?",
@@ -59,7 +59,7 @@ const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
 
 ```javascript
 // Import multiple memories at once ($0.01 for up to 100)
-await x402Fetch('POST', 'https://api.memoclaw.com/v1/store/batch', {
+await x402Fetch('POST', 'https://api.memoclaw.dev/v1/store/batch', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     memories: [
@@ -87,7 +87,7 @@ await x402Fetch('POST', 'https://api.memoclaw.com/v1/store/batch', {
 
 ```javascript
 // Recall only recent food preferences
-const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+const result = await x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
   wallet: process.env.MEMOCLAW_PRIVATE_KEY,
   body: {
     query: "food and drink preferences",
@@ -106,7 +106,7 @@ const result = await x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
 ```javascript
 // List all memories in a namespace
 const list = await x402Fetch('GET', 
-  'https://api.memoclaw.com/v1/memories?namespace=project-alpha&limit=50',
+  'https://api.memoclaw.dev/v1/memories?namespace=project-alpha&limit=50',
   { wallet: process.env.MEMOCLAW_PRIVATE_KEY }
 );
 
@@ -114,7 +114,7 @@ console.log(`Found ${list.total} memories`);
 
 // Update a memory (only provided fields change)
 await x402Fetch('PATCH',
-  `https://api.memoclaw.com/v1/memories/${memoryId}`,
+  `https://api.memoclaw.dev/v1/memories/${memoryId}`,
   {
     wallet: process.env.MEMOCLAW_PRIVATE_KEY,
     body: {
@@ -126,7 +126,7 @@ await x402Fetch('PATCH',
 
 // Set a TTL on a memory
 await x402Fetch('PATCH',
-  `https://api.memoclaw.com/v1/memories/${memoryId}`,
+  `https://api.memoclaw.dev/v1/memories/${memoryId}`,
   {
     wallet: process.env.MEMOCLAW_PRIVATE_KEY,
     body: { expires_at: "2026-06-01T00:00:00Z" }
@@ -135,7 +135,7 @@ await x402Fetch('PATCH',
 
 // Delete a specific memory
 await x402Fetch('DELETE',
-  `https://api.memoclaw.com/v1/memories/${memoryId}`,
+  `https://api.memoclaw.dev/v1/memories/${memoryId}`,
   { wallet: process.env.MEMOCLAW_PRIVATE_KEY }
 );
 ```
@@ -146,12 +146,12 @@ Using the x402 CLI directly:
 
 ```bash
 # Store a memory
-npx @x402/cli pay POST https://api.memoclaw.com/v1/store \
+npx @x402/cli pay POST https://api.memoclaw.dev/v1/store \
   --wallet ~/.wallet/key \
   --data '{"content": "User prefers vim keybindings", "importance": 0.8}'
 
 # Recall memories
-npx @x402/cli pay POST https://api.memoclaw.com/v1/recall \
+npx @x402/cli pay POST https://api.memoclaw.dev/v1/recall \
   --wallet ~/.wallet/key \
   --data '{"query": "editor preferences"}'
 ```
@@ -175,14 +175,14 @@ class AgentMemory {
       return existing.memories[0];
     }
     
-    return x402Fetch('POST', 'https://api.memoclaw.com/v1/store', {
+    return x402Fetch('POST', 'https://api.memoclaw.dev/v1/store', {
       wallet: this.wallet,
       body: { content, importance, metadata: { tags }, namespace: this.namespace }
     });
   }
 
   async recall(query, options = {}) {
-    return x402Fetch('POST', 'https://api.memoclaw.com/v1/recall', {
+    return x402Fetch('POST', 'https://api.memoclaw.dev/v1/recall', {
       wallet: this.wallet,
       body: { query, namespace: this.namespace, ...options }
     });


### PR DESCRIPTION
## Changes (non-overlapping with PRs #9 and #10)

### Bug Fix
- Fix all `memoclaw.com` → `memoclaw.dev` URLs (same fix as #9/#10, included for completeness)

### New Documentation Sections
- **`/v1/status` endpoint docs** — was missing from the API reference entirely
- **Error recovery decision tree** — retry strategies per HTTP status code, graceful degradation to local files when API is unreachable
- **Migration guide** — step-by-step instructions for moving from local markdown files to MemoClaw (extract → verify → pin → parallel run)
- **Multi-agent patterns** — how to use `agent_id` and `session_id` for per-agent isolation vs namespace-based project scoping

### SKILL.md Improvements
- **Decision tree expanded** — now includes `ingest` path for bulk/multi-fact input (was only showing single-fact `store`)
- Version bump to 1.5.0

### Housekeeping
- Added `.gitignore`
- Synced `.agents/skills/memoclaw/` copies

> **Relationship to other PRs:** #9 and #10 cover URL fixes, troubleshooting, auto-summarization helpers, decay tables, and competitor research. This PR adds *different* content: status endpoint docs, error recovery, migration guide, and multi-agent patterns. Can merge independently or after either PR.