### PR TITLE
v1.15.1: add missing --memory-type to all store examples

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memoclaw
-version: 1.15.0
+version: 1.15.1
 description: |
   Memory-as-a-Service for AI agents. Store and recall memories with semantic
   vector search. 100 free calls per wallet, then x402 micropayments.
@@ -159,7 +159,7 @@ When a session ends or a significant conversation wraps up:
 1. **Summarize key takeaways** and store as a session summary:
    ```bash
    memoclaw store "Session 2026-02-13: Discussed migration to PostgreSQL 16, decided to use pgvector for embeddings, user wants completion by March" \
-     --importance 0.7 --tags session-summary,project-alpha --namespace project-alpha
+     --importance 0.7 --tags session-summary,project-alpha --namespace project-alpha --memory-type project
    ```
 2. **Run consolidation** if many memories were created:
    ```bash
@@ -185,7 +185,7 @@ Session {date}: {brief description}
 ```bash
 # Single command to store a quick session summary
 memoclaw store "Session $(date +%Y-%m-%d): {1-sentence summary}" \
-  --importance 0.6 --tags session-summary
+  --importance 0.6 --tags session-summary --memory-type observation
 ```
 
 #### Conversation digest (via ingest)
@@ -209,7 +209,7 @@ When a new fact contradicts an existing memory:
 2. **Store the new fact** with a `supersedes` relation:
    ```bash
    memoclaw store "User now prefers spaces over tabs (changed 2026-02)" \
-     --importance 0.85 --tags preferences,code-style
+     --importance 0.85 --tags preferences,code-style --memory-type preference
    memoclaw relations create <new-id> <old-id> supersedes
    ```
 3. **Optionally update** the old memory's importance downward or add an expiration
@@ -253,7 +253,7 @@ Agent action:
 → memoclaw recall "tabs spaces indentation preference"
 → No matches found
 → memoclaw store "User prefers tabs over spaces for indentation" \
-    --importance 0.8 --tags preferences,code-style
+    --importance 0.8 --tags preferences,code-style --memory-type preference
 
 Agent response: "Got it — tabs over spaces. I'll remember that."
 ```
@@ -1141,7 +1141,7 @@ memoclaw recall "database decision" --namespace project-alpha
 
 # Session end — summarize
 memoclaw store "Session 2026-02-16: Discussed editor migration to Neovim, reviewed DB schema" \
-  --importance 0.6 --tags session-summary
+  --importance 0.6 --tags session-summary --memory-type observation
 
 # Periodic maintenance
 memoclaw consolidate --namespace default --dry-run
@@ -1240,7 +1240,7 @@ When multiple agents share the same wallet but need isolation:
 ```bash
 # Agent 1 stores in its own scope
 memoclaw store "User prefers concise answers" \
-  --agent-id agent-main --session-id session-abc
+  --importance 0.8 --memory-type preference --agent-id agent-main --session-id session-abc
 
 # Agent 2 can query across all agents or filter
 memoclaw recall "user communication style" --agent-id agent-main

--- a/examples.md
+++ b/examples.md
@@ -11,7 +11,7 @@ memoclaw init    # Interactive wallet setup — saves to ~/.memoclaw/config.json
 memoclaw status  # Check your free tier remaining
 
 # Store a memory
-memoclaw store "User prefers vim keybindings" --importance 0.8 --tags tools,preferences
+memoclaw store "User prefers vim keybindings" --importance 0.8 --tags tools,preferences --memory-type preference
 
 # Recall memories
 memoclaw recall "editor preferences" --limit 5
@@ -38,7 +38,7 @@ memoclaw recall "database decision" --namespace project-alpha
 
 # Session end — store a summary
 memoclaw store "Session 2026-02-16: Discussed editor migration, reviewed DB schema" \
-  --importance 0.6 --tags session-summary
+  --importance 0.6 --tags session-summary --memory-type observation
 
 # Periodic maintenance
 memoclaw consolidate --namespace default --dry-run
@@ -67,7 +67,7 @@ Keep memories organized per project.
 ```bash
 # Store architecture decisions scoped to a project
 memoclaw store "Team chose PostgreSQL over MongoDB for ACID requirements" \
-  --importance 0.9 --tags architecture,database --namespace project-alpha
+  --importance 0.9 --tags architecture,database --namespace project-alpha --memory-type decision
 
 # Recall only from that project
 memoclaw recall "what database did we choose?" --namespace project-alpha
@@ -87,6 +87,7 @@ Storing, updating, pinning, relating, and deleting.
 # Store
 memoclaw store "User timezone is America/Sao_Paulo (UTC-3)" \
   --importance 0.7 --tags user-info --memory-type preference
+
 
 # Update when things change
 memoclaw update <uuid> --content "User timezone is America/New_York (UTC-5)" --importance 0.8


### PR DESCRIPTION
The anti-patterns section warns 'Forgetting memory_type — Always set it' but several store examples in SKILL.md and examples.md omitted it. This PR adds appropriate --memory-type flags to all store examples for consistency.

Changes:
- SKILL.md: Added --memory-type to 6 store examples (session summaries, preferences, multi-agent)
- examples.md: Added --memory-type to 3 store examples (CLI basics, session flow, namespaces)
- Version bump to 1.15.1