### PR TITLE
chore: housekeeping — remove orphaned files, clean TODO, align README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,20 +13,23 @@ Or manually copy `SKILL.md` to your agent's skills directory.
 ## Quick Start
 
 ```bash
-# Set your private key
-export MEMOCLAW_PRIVATE_KEY=0x...
+# Setup (one-time, interactive — saves to ~/.memoclaw/config.json)
+npm install -g memoclaw
+memoclaw init
 
 # Store a memory
-memoclaw store "Meeting notes: discussed Q1 roadmap" --importance 0.8 --tags work
+memoclaw store "Meeting notes: discussed Q1 roadmap" \
+  --importance 0.8 --tags work --memory-type project
 
 # Recall memories
 memoclaw recall "what did we discuss about roadmap"
 
-# Session start - load context
-memoclaw recall "user preferences" --limit 5
+# Session start — load context
+memoclaw context "user preferences and recent decisions" --limit 10
 
-# Session end - store summary
-memoclaw store "Session 2026-02-13: Discussed project priorities" --importance 0.6 --tags session-summary
+# Session end — store summary
+memoclaw store "Session 2026-02-13: Discussed project priorities" \
+  --importance 0.6 --tags session-summary --memory-type observation
 ```
 
 ## Key Features

--- a/TODO.md
+++ b/TODO.md
@@ -1,16 +1,3 @@
 # MemoClaw Skill — Improvement Backlog
 
-_All previous items completed. Add new improvements below._
-
-## Completed
-
-1. ~~Add quick-reference card at top of SKILL.md~~ ✅
-2. ~~Replace SDK examples with CLI-focused ones in examples.md~~ ✅
-3. ~~Extract API reference to reduce SKILL.md token cost~~ ✅ (~40% smaller)
-4. ~~Document undocumented store flags~~ ✅
-5. ~~Verify memory_type values against CLI~~ ✅
-6. ~~Document `--file` and `--id-only` store flags~~ ✅
-7. ~~Document `ingest --file` and `ingest --text` flags~~ ✅
-8. ~~Fix `context --max-memories` → `--limit` (matches actual CLI)~~ ✅
-9. ~~Add `namespace stats` subcommand~~ ✅
-10. ~~Add `store --file` to quick reference~~ ✅
+_No open items. Add new improvements below as they arise._

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "memoclaw-skill",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
Bundled fixes for open housekeeping issues:

## Changes

- **Remove orphaned `package-lock.json`** — no `package.json` exists, the lockfile serves no purpose. Closes #20.
- **Clean up `TODO.md`** — all 10 items were completed (struck through). Reset to empty backlog. Closes #26.
- **Align README Quick Start with SKILL.md** — replaced `export MEMOCLAW_PRIVATE_KEY` with `memoclaw init`, added `--memory-type` flag to store examples, switched session start to `memoclaw context`. Closes #27.

## Already resolved (no changes needed)

- **#21** (Remove JS/Python SDK examples): examples.md already contains only CLI-focused examples — the SDK examples were replaced in prior work.
- **#19** (Split API reference): api-reference.md already exists as a separate file, with SKILL.md linking to it.