### PR TITLE
fix: add missing batch update pricing, expand free commands list and update CLI docs

### DIFF
--- a/.agents/skills/memoclaw/SKILL.md
+++ b/.agents/skills/memoclaw/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memoclaw
-version: 1.20.5
+version: 1.20.6
 description: |
   Memory-as-a-Service for AI agents. Store and recall memories with semantic
   vector search. 100 free calls per wallet, then x402 micropayments.
@@ -57,7 +57,7 @@ memoclaw list --sort-by importance --limit 5 # top memories (free)
 
 **Memory types:** `correction` (180d) · `preference` (180d) · `decision` (90d) · `project` (30d) · `observation` (14d) · `general` (60d)
 
-**Free commands:** list, get, delete, search, core, suggested, relations, history, export, import, namespace list, stats, count, browse, config, graph, completions
+**Free commands:** list, get, delete, bulk-delete, purge, search, core, suggested, relations, history, export, import, namespace list, stats, count, browse, config, graph, completions
 
 ---
 
@@ -323,6 +323,8 @@ memoclaw list --namespace default --limit 20
 
 # Update a memory in-place
 memoclaw update <uuid> --content "Updated text" --importance 0.9 --pinned true
+memoclaw update <uuid> --memory-type decision --namespace project-alpha
+memoclaw update <uuid> --expires-at 2026-06-01T00:00:00Z --immutable true
 
 # Delete a memory
 memoclaw delete <uuid>
@@ -473,6 +475,7 @@ The CLI handles both automatically.
 | Store batch (up to 100) | $0.04 |
 | Update memory | $0.005 |
 | Recall (semantic search) | $0.005 |
+| Batch update | $0.005 |
 | Extract facts | $0.01 |
 | Consolidate | $0.01 |
 | Ingest | $0.01 |

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memoclaw
-version: 1.20.5
+version: 1.20.6
 description: |
   Memory-as-a-Service for AI agents. Store and recall memories with semantic
   vector search. 100 free calls per wallet, then x402 micropayments.
@@ -57,7 +57,7 @@ memoclaw list --sort-by importance --limit 5 # top memories (free)
 
 **Memory types:** `correction` (180d) · `preference` (180d) · `decision` (90d) · `project` (30d) · `observation` (14d) · `general` (60d)
 
-**Free commands:** list, get, delete, search, core, suggested, relations, history, export, import, namespace list, stats, count, browse, config, graph, completions
+**Free commands:** list, get, delete, bulk-delete, purge, search, core, suggested, relations, history, export, import, namespace list, stats, count, browse, config, graph, completions
 
 ---
 
@@ -323,6 +323,8 @@ memoclaw list --namespace default --limit 20
 
 # Update a memory in-place
 memoclaw update <uuid> --content "Updated text" --importance 0.9 --pinned true
+memoclaw update <uuid> --memory-type decision --namespace project-alpha
+memoclaw update <uuid> --expires-at 2026-06-01T00:00:00Z --immutable true
 
 # Delete a memory
 memoclaw delete <uuid>
@@ -473,6 +475,7 @@ The CLI handles both automatically.
 | Store batch (up to 100) | $0.04 |
 | Update memory | $0.005 |
 | Recall (semantic search) | $0.005 |
+| Batch update | $0.005 |
 | Extract facts | $0.01 |
 | Consolidate | $0.01 |
 | Ingest | $0.01 |

--- a/api-reference.md
+++ b/api-reference.md
@@ -243,7 +243,7 @@ CLI: `memoclaw purge --namespace old-project` (deletes all in namespace)
 PATCH /v1/memories/batch
 ```
 
-Update multiple memories in one request. Charged $0.005 per request (not per memory) if any content changes trigger re-embedding.
+Update multiple memories in one request. Charged $0.005 per request (not per memory) if any content changes trigger re-embedding. No CLI equivalent — use the HTTP endpoint directly.
 
 Request:
 ```json


### PR DESCRIPTION
## Changes

Audit of SKILL.md against PRODUCT_CONTEXT.md and api-reference.md revealed several doc gaps:

1. **Pricing table missing batch update** — PRODUCT_CONTEXT and api-reference both list batch update at $0.005, but SKILL.md pricing table omitted it
2. **Free commands list incomplete** — `bulk-delete` and `purge` are free commands (confirmed in PRODUCT_CONTEXT and api-reference) but were missing from the free commands list
3. **`update` CLI docs missing flags** — The PATCH API supports `--memory-type`, `--namespace`, `--expires-at`, and `--immutable` but only `--content`, `--importance`, and `--pinned` were documented
4. **Batch update lacks CLI note** — api-reference.md now notes there's no CLI equivalent for batch update
5. **Version bump** to 1.20.6

All nested skill files synced. CI sync check should pass.