### PR TITLE
fix: use migrate command in migration section, add missing quick reference commands and global flags

### DIFF
--- a/.agents/skills/memoclaw/SKILL.md
+++ b/.agents/skills/memoclaw/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memoclaw
-version: 1.20.9
+version: 1.20.10
 description: |
   Memory-as-a-Service for AI agents. Store and recall memories with semantic
   vector search. 100 free calls per wallet, then x402 micropayments.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memoclaw
-version: 1.20.9
+version: 1.20.10
 description: |
   Memory-as-a-Service for AI agents. Store and recall memories with semantic
   vector search. 100 free calls per wallet, then x402 micropayments.


### PR DESCRIPTION
Fixes #48
Fixes #49
Fixes #50

### Changes

**Bug fix (#48):** Migration section now recommends `memoclaw migrate` (purpose-built for .md files with header splitting, dedup, auto-tagging) instead of `ingest` (general-purpose fact extractor). `ingest` is kept as a secondary option for non-.md raw text.

**Enhancement (#49):** Added management commands to quick reference section:
- `update` — update memory in-place
- `ingest` — auto-extract + dedup from raw text
- `extract` — split text into separate memories
- `consolidate` — merge similar memories
- `suggested` — proactive suggestions
- `migrate` — import .md files

**Enhancement (#50):** Added `--agent-id` and `--session-id` to global flags section (were only documented in multi-agent patterns section).

Version bumped to 1.20.9.