### PR TITLE
fix: update stale example count from 10 to 13

### DIFF
--- a/.agents/skills/memoclaw/SKILL.md
+++ b/.agents/skills/memoclaw/SKILL.md
@@ -343,7 +343,7 @@ Things that waste calls or degrade recall quality:
 
 ### Example flow
 
-> See [examples.md](examples.md) for 10 detailed scenarios including session lifecycle, migration, multi-agent patterns, and cost breakdown.
+> See [examples.md](examples.md) for 13 detailed scenarios including session lifecycle, migration, multi-agent patterns, and cost breakdown.
 
 ```
 User: "Remember, I prefer tabs over spaces"

--- a/SKILL.md
+++ b/SKILL.md
@@ -343,7 +343,7 @@ Things that waste calls or degrade recall quality:
 
 ### Example flow
 
-> See [examples.md](examples.md) for 10 detailed scenarios including session lifecycle, migration, multi-agent patterns, and cost breakdown.
+> See [examples.md](examples.md) for 13 detailed scenarios including session lifecycle, migration, multi-agent patterns, and cost breakdown.
 
 ```
 User: "Remember, I prefer tabs over spaces"


### PR DESCRIPTION
## Summary
- SKILL.md referenced "10 detailed scenarios" but examples.md has 13 examples
- Updated count to 13 in both SKILL.md and its nested copy

Fixes #85

## Test plan
- [ ] CI sync check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)